### PR TITLE
Onchain public inputs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ num = { version = "0.4", default-features = false }
 num-bigint = { version = "0.4", features = ["rand"] }
 lazy_static = "1.4.0"
 sha2          = "0.10"
-#plonky2_sha256 = {git = "https://github.com/Weobe/plonky2-sha256.git"}
+plonky2_sha256 = {git = "https://github.com/Weobe/plonky2-sha256.git"}
 
 
 [patch."https://github.com/0xPARC/plonky2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ ff = { package = "ff", version = "0.13", features = ["derive"] }
 num = { version = "0.4", default-features = false }
 num-bigint = { version = "0.4", features = ["rand"] }
 lazy_static = "1.4.0"
-
+sha2          = "0.10"
+#plonky2_sha256 = {git = "https://github.com/Weobe/plonky2-sha256.git"}
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ serde_json = "1.0.141"
 clap = { version = "4.0", features = ["derive"] }
 
 plonky2 = { git = "https://github.com/0xPARC/plonky2.git", rev = "767a098d89b8d50d8aacfdce0c0a7222e8760d37" }
-pod2 = { git="https://github.com/0xPARC/pod2", rev = "3d098c3ce6c89dbf3c26ef06e9cd4e8b8a484f1a" }
+pod2 = { git="https://github.com/0xPARC/pod2", rev = "59ec06a72f658606a068755927fa751501f04ce5", default-features = false, features = ["backend_plonky2", "zk"]}
 
 # dependencies for the wrapper
 ff = { package = "ff", version = "0.13", features = ["derive"] }
@@ -23,6 +23,10 @@ sha2          = "0.10"
 
 
 [features]
-default = []
+default = ["backend_plonky2", "zk", "mem_cache"]
 metrics = ["pod2/metrics"]
 time = ["pod2/time"]
+backend_plonky2 = ["pod2/plonky2"]
+zk = ["pod2/zk"]
+disk_cache = ["pod2/disk_cache"]
+mem_cache = ["pod2/mem_cache"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,10 @@ clap = { version = "4.0", features = ["derive"] }
 # uses custom plonky2 & pod2 branches:
 # - plonky2: with serialization of VerifierOnlyCircuitData
 # - pod2: version without EC related extra custom gates
-plonky2 = { git = "https://github.com/0xPARC/plonky2", branch="deserialize-verifieronlycircuitdata" }
-pod2 = { git="https://github.com/0xPARC/pod2", branch="tmp_disable_extra_customgates" }
+plonky2 = { git = "https://github.com/0xPARC/plonky2.git", rev = "3defd60532c8693cf5e9d2e6a8412c77ca58760f" }
+# plonky2 = { git = "https://github.com/0xPARC/plonky2", branch="deserialize-verifieronlycircuitdata" }
+# pod2 = { git="https://github.com/0xPARC/pod2", branch="tmp_disable_extra_customgates" }
+pod2 = { path = "../pod2_edu_and_ahmad" }
 
 # dependencies for the wrapper
 ff = { package = "ff", version = "0.13", features = ["derive"] }
@@ -24,6 +26,10 @@ num-bigint = { version = "0.4", features = ["rand"] }
 lazy_static = "1.4.0"
 sha2          = "0.10"
 #plonky2_sha256 = {git = "https://github.com/Weobe/plonky2-sha256.git"}
+
+
+[patch."https://github.com/0xPARC/plonky2"]
+plonky2 = { path = "../plonky2_deserialize_verifieronlydata/plonky2" }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ num = { version = "0.4", default-features = false }
 num-bigint = { version = "0.4", features = ["rand"] }
 lazy_static = "1.4.0"
 sha2          = "0.10"
-plonky2_sha256 = {git = "https://github.com/Weobe/plonky2-sha256.git"}
 
 
 [patch."https://github.com/0xPARC/plonky2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pod2-onchain"
+name = "pod2_onchain"
 version = "0.1.0"
 edition = "2024"
 
@@ -11,13 +11,8 @@ serde = "1.0.219"
 serde_json = "1.0.141"
 clap = { version = "4.0", features = ["derive"] }
 
-# uses custom plonky2 & pod2 branches:
-# - plonky2: with serialization of VerifierOnlyCircuitData
-# - pod2: version without EC related extra custom gates
-plonky2 = { git = "https://github.com/0xPARC/plonky2.git", rev = "3defd60532c8693cf5e9d2e6a8412c77ca58760f" }
-# plonky2 = { git = "https://github.com/0xPARC/plonky2", branch="deserialize-verifieronlycircuitdata" }
-# pod2 = { git="https://github.com/0xPARC/pod2", branch="tmp_disable_extra_customgates" }
-pod2 = { path = "../pod2_edu_and_ahmad" }
+plonky2 = { git = "https://github.com/0xPARC/plonky2.git", rev = "767a098d89b8d50d8aacfdce0c0a7222e8760d37" }
+pod2 = { git="https://github.com/0xPARC/pod2", rev = "78b49f2437bc6e00be2c371cbf7ac5218792d4d0" }
 
 # dependencies for the wrapper
 ff = { package = "ff", version = "0.13", features = ["derive"] }
@@ -26,9 +21,6 @@ num-bigint = { version = "0.4", features = ["rand"] }
 lazy_static = "1.4.0"
 sha2          = "0.10"
 
-
-[patch."https://github.com/0xPARC/plonky2"]
-plonky2 = { path = "../plonky2_deserialize_verifieronlydata/plonky2" }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ serde_json = "1.0.141"
 clap = { version = "4.0", features = ["derive"] }
 
 plonky2 = { git = "https://github.com/0xPARC/plonky2.git", rev = "767a098d89b8d50d8aacfdce0c0a7222e8760d37" }
-pod2 = { git="https://github.com/0xPARC/pod2", rev = "78b49f2437bc6e00be2c371cbf7ac5218792d4d0" }
+pod2 = { git="https://github.com/0xPARC/pod2", rev = "3d098c3ce6c89dbf3c26ef06e9cd4e8b8a484f1a" }
 
 # dependencies for the wrapper
 ff = { package = "ff", version = "0.13", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # pod2-onchain
+Prove POD2s onchain in Ethereum.
 
 ## Usage
 - Run: `bash full-flow.sh`
@@ -6,15 +7,35 @@
     - generate the pod proof: `cargo test --release test_pod_flow -- --nocapture`
       - to use the non-pod plonky2 circuit (faster to run) run the test `test_simple_proof_flow`
     - generate the groth16 proof: `go run main.go`
+      - this will also generate the Solidity smart contract, located at
+        `outputs/Verifier.sol`, ready to be deployed
 
 
 For an example on how to use the rust lib, check the test [`test_pod_flow`](https://github.com/0xPARC/pod2-onchain/blob/main/src/lib.rs)
 
 ![](pod2-onchain-diagram.png)
 
+For the public inputs onchain verification, we use the approach described at https://eprint.iacr.org/2025/1500 and https://eprint.iacr.org/2024/2099 section 4.2.1.
+
+## Benchmarks
+
+In an AMD Ryzen 9 5900XT 16cores linux server:
+- plonky2 encapsulation proof: `3.08s`
+- groth16 proof: `5.2M` r1cs constraints, `10s`
+
+Wrapper circuit proving times for different pod circuit sizes:
+
+| pod circuit size | pod proving time | wrapper circuit size | wrapper proving time |
+|------------------|------------------|----------------------|----------------------|
+| 2^16             | 15.8s            | 4784                 | 3.09s                |
+| 2^17             | 33.3s            | 5175                 | 3.09s                |
+| 2^18             | 73.5s            | 5411                 | 3.09s                |
+| 2^19             | 153.8s           | 5646                 | 3.09s                |
+
 
 ## Acknowledgements
 This repo relies on the following projects:
 - Plonky2: https://github.com/0xPolygonZero/plonky2
 - Pod2: https://github.com/0xPARC/pod2
+- Gnark: https://github.com/Consensys/gnark
 - Gnark plonky2 verifier: https://github.com/succinctlabs/gnark-plonky2-verifier

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ For an example on how to use the rust lib, check the test [`test_pod_flow`](http
 
 ![](pod2-onchain-diagram.png)
 
-For the public inputs onchain verification, we use the approach described at https://eprint.iacr.org/2025/1500 and https://eprint.iacr.org/2024/2099 section 4.2.1.
 
 ## Benchmarks
 
@@ -39,3 +38,4 @@ This repo relies on the following projects:
 - Pod2: https://github.com/0xPARC/pod2
 - Gnark: https://github.com/Consensys/gnark
 - Gnark plonky2 verifier: https://github.com/succinctlabs/gnark-plonky2-verifier
+- For the public inputs onchain verification, we use the approach described at https://eprint.iacr.org/2025/1500 and https://eprint.iacr.org/2024/2099 section 4.2.1.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use itertools::Itertools;
 use std::fs;
 use std::io::Write;
-use std::iter;
 use std::ops::Deref;
 use std::path::Path;
 use std::time::Instant;


### PR DESCRIPTION
For the hashing of the public inputs, we use the approach described at https://eprint.iacr.org/2025/1500 and https://eprint.iacr.org/2024/2099 section 4.2.1.